### PR TITLE
Remove usage of private SSH key in GitHub actions

### DIFF
--- a/.github/workflows/depedencies.yml
+++ b/.github/workflows/depedencies.yml
@@ -8,9 +8,6 @@ jobs:
     name: Check missing composer requirements
     runs-on: ubuntu-18.04
     steps:
-      -   uses: webfactory/ssh-agent@master
-          with:
-            ssh-private-key: ${{ secrets.ORG_SSH_PRIVATE_KEY }}
       -   uses: actions/checkout@v2
       -   name: Configure Composer
           run: |

--- a/.github/workflows/depedencies.yml
+++ b/.github/workflows/depedencies.yml
@@ -12,7 +12,6 @@ jobs:
       -   name: Configure Composer
           run: |
             mkdir -p ~/.composer/cache
-            umask 077 && cat > ~/.composer/auth.json <<< '${{ secrets.ORG_COMPOSER_AUTH_JSON }}'
       -   name: Konfiguriere PHP-Version und -Einstellungen im Worker-Node
           uses: shivammathur/setup-php@v2
           with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       -   name: Configure Composer
           run: |
             mkdir -p ~/.composer/cache
-            umask 077 && cat > ~/.composer/auth.json <<< '${{ secrets.ORG_COMPOSER_AUTH_JSON }}'
       -   run: mkdir --mode=777 -p $GITHUB_WORKSPACE/{tmp,logs}
       -   name: Konfiguriere PHP-Version und -Einstellungen im Worker-Node
           uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,6 @@ jobs:
     name: PHPUnit
     runs-on: ubuntu-18.04
     steps:
-      -   uses: webfactory/ssh-agent@master
-          with:
-            ssh-private-key: ${{ secrets.ORG_SSH_PRIVATE_KEY }}
       -   uses: actions/checkout@v2
       -   name: Configure Composer
           run: |


### PR DESCRIPTION
This is not needed, as we don't depend on any private repositories – and it made the CI runs fail since the repository was public