### PR TITLE
Führe GitHub Actions Workflows mit Ubuntu 20.04 aus

### DIFF
--- a/.github/workflows/depedencies.yml
+++ b/.github/workflows/depedencies.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   composer-require-checker:
     name: Check missing composer requirements
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       -   uses: actions/checkout@v2
       -   name: Configure Composer

--- a/.github/workflows/fix-cs-php.yml
+++ b/.github/workflows/fix-cs-php.yml
@@ -12,7 +12,7 @@ name: Coding Standards
 jobs:
     open-pr-for-cs-violations:
         name: PHP-CS-Fixer
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
 
             -   name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   PHPUnit:
     name: PHPUnit
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       -   uses: actions/checkout@v2
       -   name: Configure Composer


### PR DESCRIPTION
Der für uns wesentliche Unterschied sollte die Verwendung von MySQL 8 sein. Auf diese Weise können wir testen, ob wir vorwärtskompatibel sind.
