### PR TITLE
Hotfix: Consider result of FilterStrategy in Query Cache

### DIFF
--- a/src/DependencyInjection/OnRequestDependencyInjector.php
+++ b/src/DependencyInjection/OnRequestDependencyInjector.php
@@ -62,5 +62,6 @@ final class OnRequestDependencyInjector implements EventSubscriberInterface
         $visibilityFilter = $filterCollection->getFilter(VisibilityColumnConsideringSQLFilter::NAME);
 
         $visibilityFilter->injectDependencies($this->filterStrategy, $this->visibilityColumnRetriever);
+        $visibilityFilter->setParameter('visibility', $this->filterStrategy->getFilterSql(''));
     }
 }


### PR DESCRIPTION
With an activate query cache, queries will be cached at a key generated in https://github.com/doctrine/orm/blob/152c04c03d68d39f485d367713dd69dec0f4106d/lib/Doctrine/ORM/Query.php#L792-L803 . If a SQLFilter does not produce static SQL but dynamic SQL, you need to call SQLFilter->setParameter for the dynamic parts, in order for them to be considered for the cache key: https://github.com/doctrine/orm/blob/152c04c03d68d39f485d367713dd69dec0f4106d/lib/Doctrine/ORM/Query/Filter/SQLFilter.php#L178-L181 . I.e. without setParameter() calls, the first generated query was cached and whatever visibility value the FilterStrategy had determined was reused for future requests.

@see https://github.com/doctrine/orm/issues/3955