### PR TITLE
Allow filter strategies to set parameters (for invalidating the Doctrine cache) (Case 142739)

### DIFF
--- a/src/Filter/ParameterCollection.php
+++ b/src/Filter/ParameterCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Webfactory\VisibilityFilterBundle\Filter;
+
+use Doctrine\DBAL\Types\Types;
+use InvalidArgumentException;
+
+interface ParameterCollection
+{
+    /**
+     * Sets a parameter that can be used by the filter.
+     *
+     * @param string        $name  Name of the parameter.
+     * @param string        $value Value of the parameter.
+     * @param Types::*|null $type  The parameter type. If specified, the given value will be run through
+     *                             the type conversion of this type. This is usually not needed for
+     *                             strings and numeric types.
+     */
+    public function setParameter(string $name, $value, $type = null): void;
+
+    /**
+     * Gets a parameter to use in a query.
+     *
+     * The function is responsible for the right output escaping to use the
+     * value in a query.
+     *
+     * @param string $name Name of the parameter.
+     *
+     * @return string The SQL escaped parameter to use in a query.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getParameter(string $name);
+
+    /**
+     * Checks if a parameter was set for the filter.
+     *
+     * @param string $name Name of the parameter.
+     */
+    public function hasParameter(string $name): bool;
+}

--- a/src/Filter/SQLFilterAsParameterCollection.php
+++ b/src/Filter/SQLFilterAsParameterCollection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Webfactory\VisibilityFilterBundle\Filter;
+
+use Doctrine\ORM\Query\Filter\SQLFilter;
+
+class SQLFilterAsParameterCollection implements ParameterCollection
+{
+    /**
+     * @var SQLFilter
+     */
+    private $sqlFilter;
+
+    public function __construct(SQLFilter $sqlFilter)
+    {
+        $this->sqlFilter = $sqlFilter;
+    }
+
+    final public function setParameter($name, $value, $type = null): void
+    {
+        $this->sqlFilter->setParameter($name, $value, $type);
+    }
+
+    final public function getParameter($name)
+    {
+        return $this->sqlFilter->getParameter($name);
+    }
+
+    final public function hasParameter($name): bool
+    {
+        return $this->sqlFilter->hasParameter($name);
+    }
+}

--- a/src/Filter/Strategy/FilterStrategy.php
+++ b/src/Filter/Strategy/FilterStrategy.php
@@ -2,15 +2,26 @@
 
 namespace Webfactory\VisibilityFilterBundle\Filter\Strategy;
 
+use Webfactory\VisibilityFilterBundle\Filter\ParameterCollection;
+
 /**
  * Implement this to apply custom filtering logic to your project.
  */
 interface FilterStrategy
 {
     /**
+     * Adds all parameters to the collection that affect the resulting filter SQL string. If the filter SQL depends on
+     * factors other than parameters added to the collection, the cache won't be invalidated, which will have undesired
+     * consequences!
+     *
+     * So please add all parameters to the collection.
+     */
+    public function addParameters(ParameterCollection $parameters): void;
+
+    /**
      * @param string $visibilityFieldAlias SQL alias for the visibility field of the requested entity
      *
      * @return string A string of SQL that will be included in the WHERE clause to any query requesting an entity with a visibility field
      */
-    public function getFilterSql(string $visibilityFieldAlias): string;
+    public function getFilterSql(string $visibilityFieldAlias, ParameterCollection $parameters): string;
 }

--- a/src/Filter/Strategy/ValueInField.php
+++ b/src/Filter/Strategy/ValueInField.php
@@ -2,6 +2,10 @@
 
 namespace Webfactory\VisibilityFilterBundle\Filter\Strategy;
 
+use Webfactory\VisibilityFilterBundle\Filter\ParameterCollection;
+use function is_bool;
+use function is_string;
+
 /**
  * Filters queries so that only entries with a certain value in their visibility field (@see VisibilityColumn) will
  * be retrieved from the database.
@@ -21,7 +25,12 @@ final class ValueInField implements FilterStrategy
         $this->visibleValue = $visibleValue;
     }
 
-    public function getFilterSql(string $visibilityFieldAlias): string
+    public function addParameters(ParameterCollection $parameters): void
+    {
+        // not needed, as $this->visibleValue is immutable
+    }
+
+    public function getFilterSql(string $visibilityFieldAlias, ParameterCollection $parameters): string
     {
         return $visibilityFieldAlias.' = '.$this->getSqlLiteral($this->visibleValue);
     }
@@ -31,11 +40,11 @@ final class ValueInField implements FilterStrategy
      */
     private function getSqlLiteral($value): string
     {
-        if (\is_string($value)) {
+        if (is_string($value)) {
             return '"'.$value.'"';
         }
 
-        if (\is_bool($value)) {
+        if (is_bool($value)) {
             return $value ? '1' : '0';
         }
 


### PR DESCRIPTION
As discussed in https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/18#issuecomment-1063235230, this PR provides a better way to invalidate the Doctrine cache when the filter SQL changes.

#18 Already provides a backwards-compatible fix that generates full filter SQL and adds it as a parameter. This PR allows the FilterStrategies to set and retrieve their parameters themselves.

This presents a breaking change, as the interface for FilterStrategies is changed.

- [x] Provide an interface to set and retreive parameters from the FilterStrategy
- [ ] Make this interface work and replace the hotfix introduced in #18