### PR TITLE
Erlaube Symfony 6-Komponenten (Case 173415)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       -   run: vendor/bin/phpunit -vvv
 
   PHPUnit_PHP81:
-    name: PHPUnit (PHP 8.2)
+    name: PHPUnit (PHP 8.1)
     runs-on: ubuntu-22.04
     steps:
       -   uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "doctrine/annotations": "^1.12",
         "doctrine/doctrine-bundle": "^1.12.13|^2.0",
         "doctrine/orm": "^2.7.2",
-        "symfony/config": "^4.4|^5.4|^6.4",
-        "symfony/dependency-injection": "^4.4|^5.4|^6.4",
-        "symfony/event-dispatcher": "^4.4|^5.4|^6.4",
-        "symfony/http-kernel": "^4.4|^5.4|^6.4"
+        "symfony/config": "^5.4|^6.4",
+        "symfony/dependency-injection": "^5.4|^6.4",
+        "symfony/event-dispatcher": "^5.4|^6.4",
+        "symfony/http-kernel": "^5.4|^6.4"
     },
     "config": {
         "sort-packages": true
@@ -28,7 +28,7 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.5",
         "phpunit/phpunit": "^8.5",
-        "symfony/framework-bundle": "^4.4|^5.4|^6.4",
-        "symfony/yaml": "^4.4|^5.4|^6.4"
+        "symfony/framework-bundle": "^5.4|^6.4",
+        "symfony/yaml": "^5.4|^6.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "doctrine/annotations": "^1.12",
         "doctrine/doctrine-bundle": "^1.12.13|^2.0",
         "doctrine/orm": "^2.7.2",
-        "symfony/config": "^4.4|^5.4",
-        "symfony/dependency-injection": "^4.4|^5.4",
-        "symfony/event-dispatcher": "^4.4|^5.4",
-        "symfony/http-kernel": "^4.4|^5.4"
+        "symfony/config": "^4.4|^5.4|^6.4",
+        "symfony/dependency-injection": "^4.4|^5.4|^6.4",
+        "symfony/event-dispatcher": "^4.4|^5.4|^6.4",
+        "symfony/http-kernel": "^4.4|^5.4|^6.4"
     },
     "config": {
         "sort-packages": true
@@ -28,7 +28,7 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.5",
         "phpunit/phpunit": "^8.5",
-        "symfony/framework-bundle": "^4.4|^5.4",
-        "symfony/yaml": "^4.4|^5.4"
+        "symfony/framework-bundle": "^4.4|^5.4|^6.4",
+        "symfony/yaml": "^4.4|^5.4|^6.4"
     }
 }

--- a/src/DependencyInjection/OnRequestDependencyInjector.php
+++ b/src/DependencyInjection/OnRequestDependencyInjector.php
@@ -47,8 +47,8 @@ final class OnRequestDependencyInjector implements EventSubscriberInterface
 
     public function setUpFilter(RequestEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
-            return; // filter only needs to be set up once (in the master request), as all sub request share the filter instance with the master request
+        if (!$event->isMainRequest()) {
+            return; // filter only needs to be set up once (in the main request), as all sub request share the filter instance with the master request
         }
 
         $filterCollection = $this->entityManager->getFilters();

--- a/tests/DependencyInjection/OnRequestDependencyInjectorTest.php
+++ b/tests/DependencyInjection/OnRequestDependencyInjectorTest.php
@@ -47,7 +47,7 @@ class OnRequestDependencyInjectorTest extends KernelTestCase
      */
     public function enables_filter_on_request(): void
     {
-        $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
         $this->eventDispatcher->dispatch($masterRequestEvent, KernelEvents::REQUEST);
 
         static::assertTrue($this->entityManager->getFilters()->isEnabled(VisibilityColumnConsideringSQLFilter::NAME));
@@ -60,7 +60,7 @@ class OnRequestDependencyInjectorTest extends KernelTestCase
     {
         $this->entityManager->getConfiguration()->addFilter(VisibilityColumnConsideringSQLFilter::NAME, VisibilityColumnConsideringSQLFilterMock::class);
 
-        $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
         $this->eventDispatcher->dispatch($masterRequestEvent, KernelEvents::REQUEST);
 
         /** @var VisibilityColumnConsideringSQLFilterMock $filterMock */

--- a/tests/DependencyInjection/OnRequestDependencyInjectorTest.php
+++ b/tests/DependencyInjection/OnRequestDependencyInjectorTest.php
@@ -37,7 +37,7 @@ class OnRequestDependencyInjectorTest extends KernelTestCase
         parent::setUp();
         static::bootKernel();
 
-        $container = static::$container;
+        $container = static::getContainer();
         $this->eventDispatcher = $container->get(EventDispatcherInterface::class);
         $this->entityManager = $container->get(EntityManagerInterface::class);
     }

--- a/tests/DependencyInjection/OnRequestDependencyInjectorTest.php
+++ b/tests/DependencyInjection/OnRequestDependencyInjectorTest.php
@@ -27,7 +27,7 @@ class OnRequestDependencyInjectorTest extends KernelTestCase
      */
     private $entityManager;
 
-    public static function getKernelClass()
+    public static function getKernelClass(): string
     {
         return TestKernel::class;
     }

--- a/tests/Filter/VisibilityColumnConsideringSQLFilterTest.php
+++ b/tests/Filter/VisibilityColumnConsideringSQLFilterTest.php
@@ -22,7 +22,7 @@ class VisibilityColumnConsideringSQLFilterTest extends KernelTestCase
      */
     private $entityManager;
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return TestKernel::class;
     }

--- a/tests/Filter/VisibilityColumnConsideringSQLFilterTest.php
+++ b/tests/Filter/VisibilityColumnConsideringSQLFilterTest.php
@@ -43,7 +43,7 @@ class VisibilityColumnConsideringSQLFilterTest extends KernelTestCase
 
         // activate filter by simulating a request
         $eventDispatcher = static::$container->get(EventDispatcherInterface::class);
-        $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
         $eventDispatcher->dispatch($masterRequestEvent, KernelEvents::REQUEST);
     }
 

--- a/tests/Filter/VisibilityColumnConsideringSQLFilterTest.php
+++ b/tests/Filter/VisibilityColumnConsideringSQLFilterTest.php
@@ -31,7 +31,7 @@ class VisibilityColumnConsideringSQLFilterTest extends KernelTestCase
     {
         self::bootKernel();
 
-        $this->entityManager = static::$container->get(EntityManagerInterface::class);
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
 
         // create database schema
         $schemaTool = new SchemaTool($this->entityManager);
@@ -42,7 +42,7 @@ class VisibilityColumnConsideringSQLFilterTest extends KernelTestCase
         ]);
 
         // activate filter by simulating a request
-        $eventDispatcher = static::$container->get(EventDispatcherInterface::class);
+        $eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
         $masterRequestEvent = new RequestEvent(static::$kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
         $eventDispatcher->dispatch($masterRequestEvent, KernelEvents::REQUEST);
     }

--- a/tests/Filter/VisibilityColumnRetrieverTest.php
+++ b/tests/Filter/VisibilityColumnRetrieverTest.php
@@ -34,7 +34,7 @@ class VisibilityColumnRetrieverTest extends KernelTestCase
         parent::setUp();
         static::bootKernel();
 
-        $container = static::$container;
+        $container = static::getContainer();
         $this->visibilityColumnRetriever = $container->get(VisibilityColumnRetriever::class);
         $this->classMetadataFactory = $container->get(EntityManagerInterface::class)->getMetadataFactory();
     }

--- a/tests/Filter/VisibilityColumnRetrieverTest.php
+++ b/tests/Filter/VisibilityColumnRetrieverTest.php
@@ -24,7 +24,7 @@ class VisibilityColumnRetrieverTest extends KernelTestCase
      */
     private $classMetadataFactory;
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return TestKernel::class;
     }

--- a/tests/Fixtures/Kernel/TestKernel.php
+++ b/tests/Fixtures/Kernel/TestKernel.php
@@ -11,7 +11,7 @@ use Webfactory\VisibilityFilterBundle\VisibilityFilterBundle;
 
 class TestKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [new FrameworkBundle(), new DoctrineBundle(), new VisibilityFilterBundle()];
     }


### PR DESCRIPTION
* **Allow Symfony 6 components:** https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/35/commits/87e09b904506c70bac867801ba389d740ed23af0
* **Add return types:** https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/35/commits/a61d87b58bb3f1deda2beda44322530ffbfe284d
* **Use `MASTER_REQUEST`** instead of `MAIN_REQUEST`: https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/35/commits/050ff13c8aaf8af823e72ef347b497180f6bec9c
* **Use `static::getContainer()`** instead of `static::$container` in tests: https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/35/commits/39744c7f60d436f7c439dabcaa6332d9271a423c
* **Fix PHP version in test:** https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/35/commits/b2a9ff8f7d54ac3823b6017f38950a58ecdceaec
* **Drop Symfony 4 compitibility.** Symfony 4 compatibility is no longer possible, as it doesn't provide the method `KernelTestCase::getContainer()`: https://github.com/webfactory/webfactory-visibility-filter-bundle/pull/35/commits/68584b715b381876f40453f60bcdd28b6ae94b0e